### PR TITLE
Update GH Actions Workflow & Fix Simulation Manifest Path

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -8,14 +8,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Extract schema URL
-      id: get_schema
-      run: echo "::set-output name=url::$(jq -r .\"$schema\" .hornet/cad_manifest.json)"
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: Validate manifest
-      uses: sourcemeta/jsonschema@v9
-      with:
-        command: validate
-        args: >
-        --schema ${{ steps.get_schema.outputs.url }}
-        --instance .hornet/cad_manifest.json
+    - name: Install JSON Schema CLI
+      uses: sourcemeta/jsonschema@v11.0.0
+
+    - name: Validate CAD manifest
+      run: |
+        schema_url=$(jq -r '.["$schema"]' .hornet/cad_manifest.json)
+        curl -o cad_schema.json "$schema_url"
+        jsonschema validate cad_schema.json .hornet/cad_manifest.json --json
+
+    - name: Validate Sim manifest
+      run: |
+        schema_url=$(jq -r '.["$schema"]' .hornet/sim_manifest.json)
+        curl -o sim_schema.json "$schema_url"
+        jsonschema validate sim_schema.json .hornet/sim_manifest.json --json

--- a/.hornet/sim_manifest.json
+++ b/.hornet/sim_manifest.json
@@ -3,7 +3,7 @@
   "mappings": [
     {
       "component_ref": {
-        "cad_manifest_path": "./.hornet/cad_manifest.json",
+        "cad_manifest_path": "./cad_manifest.json",
         "component_id": "EPI Disk"
       },
       "material": {


### PR DESCRIPTION
Hi @crexroth,

Following up on our conversation, I’ve made some updates in https://github.com/ITISFoundation/hornet-manifest-spec/pull/10.
This PR also includes an updated GitHub Actions workflow and a small fix in your simulation manifest.

Changes:

- Updated GitHub Actions workflow to validate Hornet CAD and simulation manifests
- Fixed minor path issue in the simulation manifest